### PR TITLE
Service key support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.idea
+

--- a/lib/Errors.js
+++ b/lib/Errors.js
@@ -1,0 +1,3 @@
+module.exports = {
+	OPTIONS_OBJECT_MISSING_PROPERTIES: "Failed to initialize. Options object should contains following properties: clientId, secret, authorizationEndpoint, tokenEndpoint, callbackUrl"
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,9 +16,17 @@
 var packageVersion = require('./../package.json').version;
 console.log("bms-mca-token-validation-strategy initialized :: v" + packageVersion);
 
-var ImfServiceStrategy = require('./imf-service-strategy');
-var ImfBackendStrategy = require('./imf-backend-strategy');
-var ImfResourceStrategy = require('./imf-resource-strategy');
+// Used to protect services.
+var MCAServiceStrategy = require('./imf-service-strategy');
+
+// Used to protect backends. Checks Authorization header in incoming requests and validates it using MCA public certificate
+var MCABackendStrategy = require('./imf-backend-strategy');
+
+// Used to protect resources.
+var MCAResourceStrategy = require('./imf-resource-strategy');
+
+// Used to protect websites. Implements OAuth2 Authorization Code flow
+var MCAWebSiteStrategy = require('./mca-website-strategy');
 /** 
  * Expose `Strategy` directly from package.
  */
@@ -28,8 +36,9 @@ var ImfResourceStrategy = require('./imf-resource-strategy');
  * Export constructors.
  */
 exports = module.exports = {
-		MCAServiceStrategy: ImfServiceStrategy,
-		MCABackendStrategy: ImfBackendStrategy,
-		MCAResourceStrategy: ImfResourceStrategy
+	MCAServiceStrategy: MCAServiceStrategy,
+	MCABackendStrategy: MCABackendStrategy,
+	MCAResourceStrategy: MCAResourceStrategy,
+	MCAWebSiteStrategy: MCAWebSiteStrategy
 }
 

--- a/lib/mca-website-strategy.js
+++ b/lib/mca-website-strategy.js
@@ -1,0 +1,137 @@
+/**
+ *  Copyright 2014 IBM Corp. All Rights Reserved
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+var passportStrategy = require('passport-strategy');
+var util = require('util');
+var logger = require('log4js').getLogger('mca-website-strategy');
+var request = require('request');
+
+var FilterUtil = require('./util/filter-util');
+var ERRORS = require("./Errors");
+
+function Strategy(options) {
+	var self = this;
+	options = options || {};
+	var mcaCredentials = FilterUtil.getMcaServiceCredentials();
+
+	this.clientId = (options.clientId) ? options.clientId : mcaCredentials.clientId;
+	this.secret = (options.secret) ? options.secret : mcaCredentials.secret;
+	this.authorizationEndpoint = (options.authorizationEndpoint) ? options.authorizationEndpoint : mcaCredentials.authorizationEndpoint;
+	this.tokenEndpoint = (options.tokenEndpoint) ? options.tokenEndpoint : mcaCredentials.tokenEndpoint;
+	this.callbackUrl = options.callbackUrl;
+
+	logger.debug("clientiD", this.clientId);
+	logger.debug("secret", this.secret.substr(0, 1) + "............................" + this.secret.substr(this.secret.length - 1));
+	logger.debug("authorizationEndpoint", this.authorizationEndpoint);
+	logger.debug("tokenEndpoint", this.tokenEndpoint);
+	logger.debug("callbackUrl", this.callbackUrl);
+
+	if (typeof(this.clientId) !== "string" ||
+		typeof(this.secret) !== "string" ||
+		typeof(this.authorizationEndpoint) !== "string" ||
+		typeof(this.tokenEndpoint) !== "string" ||
+		typeof(this.callbackUrl) !== "string") {
+		throw new TypeError(ERRORS.OPTIONS_OBJECT_MISSING_PROPERTIES);
+	}
+
+	this.name = Strategy.NAME;
+}
+
+util.inherits(Strategy, passportStrategy.Strategy);
+
+Strategy.prototype.authenticate = function(req, options) {
+	logger.debug("authenticate", req.url, ", user :: ", req.user);
+	options = options || {};
+
+	// Handle possible error
+	if (req.query && req.query.error) {
+		logger.error(req.query.error);
+		logger.error(req.query.error_description);
+		return this.fail({ message: req.query.error_description });
+	}
+
+	// Handle oauth callback
+	if (options.isOAuthCallback) {
+		return retrieveAccessToken(req, this, options);
+	}
+
+	// Check for authentication
+	if (req.user){
+		logger.debug("Request already authenticated");
+		return this.pass();
+	}
+
+	// Redirect to authorization endpoint
+	logger.debug("Request not authenticated, redirecting to authorizationEndpoint");
+	var redirectUrl = this.authorizationEndpoint;
+	redirectUrl += "?response_type=authorization_code";
+	redirectUrl += "&client_id=" + this.clientId;
+	redirectUrl += "&redirect_uri=" + this.callbackUrl;
+	req.session.originalUrl = req.url;
+	this.redirect(redirectUrl);
+}
+
+function retrieveAccessToken(req, strategy, options){
+	logger.debug("retrieveAccessToken");
+
+	var formData = {
+		grant_type: "authorization_code",
+		client_id: strategy.clientId,
+		redirect_uri: strategy.callbackUrl,
+		code: req.query.code
+	}
+
+	request.post({
+		url: strategy.tokenEndpoint,
+		form: formData
+	}, function (err, response, body){
+		if (err){
+			logger.error(err);
+			return strategy.fail();
+		}
+
+		if (response && response.statusCode == 200 && body){
+			logger.debug("Got tokens, parsing", body)
+			var parsedBody = JSON.parse(body);
+			req.session = req.session || {};
+			req.session.accessToken = parsedBody.access_token;
+			req.session.idToken = parsedBody.id_token;
+			var idTokenComponents = parsedBody.id_token.split("."); // [header, payload, signature]
+			var decodedIdentity= new Buffer(idTokenComponents[1],"base64").toString();
+			req.securityContext = JSON.parse(decodedIdentity);
+			req.session.securityContext = JSON.parse(decodedIdentity);
+			return strategy.success(req.securityContext);
+		}
+
+		logger.error("Failed to get tokens", body);
+		return strategy.fail();
+	}).auth(strategy.clientId, strategy.secret);
+}
+
+Strategy.MCA_WEBSITE_STRATEGY = "mca-website-strategy";
+Strategy.NAME = Strategy.MCA_WEBSITE_STRATEGY;
+Strategy.MCA_LOGIN_URL = "/" + Strategy.MCA_WEBSITE_STRATEGY + "/oauth/login";
+Strategy.setup = function (passport) {
+	passport.serializeUser(function (user, done) {
+		done(null, user || {});
+	});
+
+	passport.deserializeUser(function (user, done) {
+		done(null, user);
+	});
+}
+
+exports = module.exports = Strategy;

--- a/lib/mca-website-strategy.js
+++ b/lib/mca-website-strategy.js
@@ -77,7 +77,7 @@ Strategy.prototype.authenticate = function(req, options) {
 	// Redirect to authorization endpoint
 	logger.debug("Request not authenticated, redirecting to authorizationEndpoint");
 	var redirectUrl = this.authorizationEndpoint;
-	redirectUrl += "?response_type=authorization_code";
+	redirectUrl += "?response_type=code";
 	redirectUrl += "&client_id=" + this.clientId;
 	redirectUrl += "&redirect_uri=" + this.callbackUrl;
 	req.session.originalUrl = req.url;
@@ -88,7 +88,7 @@ function retrieveAccessToken(req, strategy, options){
 	logger.debug("retrieveAccessToken");
 
 	var formData = {
-		grant_type: "authorization_code",
+		grant_type: "code",
 		client_id: strategy.clientId,
 		redirect_uri: strategy.callbackUrl,
 		code: req.query.code

--- a/lib/mca-website-strategy.js
+++ b/lib/mca-website-strategy.js
@@ -23,7 +23,6 @@ var FilterUtil = require('./util/filter-util');
 var ERRORS = require("./Errors");
 
 function Strategy(options) {
-	var self = this;
 	options = options || {};
 	var mcaCredentials = FilterUtil.getMcaServiceCredentials();
 
@@ -52,7 +51,7 @@ function Strategy(options) {
 
 util.inherits(Strategy, passportStrategy.Strategy);
 
-Strategy.prototype.authenticate = function(req, options) {
+Strategy.prototype.authenticate = function (req, options) {
 	logger.debug("authenticate", req.url, ", user :: ", req.user);
 	options = options || {};
 
@@ -60,7 +59,7 @@ Strategy.prototype.authenticate = function(req, options) {
 	if (req.query && req.query.error) {
 		logger.error(req.query.error);
 		logger.error(req.query.error_description);
-		return this.fail({ message: req.query.error_description });
+		return this.fail({message: req.query.error_description});
 	}
 
 	// Handle oauth callback
@@ -69,7 +68,7 @@ Strategy.prototype.authenticate = function(req, options) {
 	}
 
 	// Check for authentication
-	if (req.user){
+	if (req.user) {
 		logger.debug("Request already authenticated");
 		return this.pass();
 	}
@@ -82,9 +81,9 @@ Strategy.prototype.authenticate = function(req, options) {
 	redirectUrl += "&redirect_uri=" + this.callbackUrl;
 	req.session.originalUrl = req.url;
 	this.redirect(redirectUrl);
-}
+};
 
-function retrieveAccessToken(req, strategy, options){
+function retrieveAccessToken(req, strategy) {
 	logger.debug("retrieveAccessToken");
 
 	var formData = {
@@ -92,25 +91,25 @@ function retrieveAccessToken(req, strategy, options){
 		client_id: strategy.clientId,
 		redirect_uri: strategy.callbackUrl,
 		code: req.query.code
-	}
+	};
 
 	request.post({
 		url: strategy.tokenEndpoint,
 		form: formData
-	}, function (err, response, body){
-		if (err){
+	}, function (err, response, body) {
+		if (err) {
 			logger.error(err);
 			return strategy.fail();
 		}
 
-		if (response && response.statusCode == 200 && body){
-			logger.debug("Got tokens, parsing", body)
+		if (response && response.statusCode == 200 && body) {
+			logger.debug("Got tokens, parsing", body);
 			var parsedBody = JSON.parse(body);
 			req.session = req.session || {};
 			req.session.accessToken = parsedBody.access_token;
 			req.session.idToken = parsedBody.id_token;
 			var idTokenComponents = parsedBody.id_token.split("."); // [header, payload, signature]
-			var decodedIdentity= new Buffer(idTokenComponents[1],"base64").toString();
+			var decodedIdentity = new Buffer(idTokenComponents[1], "base64").toString();
 			req.securityContext = JSON.parse(decodedIdentity);
 			req.session.securityContext = JSON.parse(decodedIdentity);
 			return strategy.success(req.securityContext);
@@ -132,6 +131,6 @@ Strategy.setup = function (passport) {
 	passport.deserializeUser(function (user, done) {
 		done(null, user);
 	});
-}
+};
 
 exports = module.exports = Strategy;

--- a/lib/util/filter-util.js
+++ b/lib/util/filter-util.js
@@ -88,12 +88,17 @@ FilterUtil.getArrayFromString = function(value,delim) {
 	return array;
 }
 
+FilterUtil.getMcaServiceCredentials = function (){
+	var mcaServiceInfo = getImfService();
+	var credentials = mcaServiceInfo && mcaServiceInfo["credentials"];
+	return credentials;
+}
+
 function getImfService() {
-	
-	if (! imfService) {
+	if (!imfService) {
 		var vcapServices = FilterUtil.getJson(process.env['VCAP_SERVICES']);
 		for (var prop in vcapServices) {
-			if (prop.indexOf('AdvancedMobileAccess') == 0 && vcapServices[prop].length>0) {
+			if (prop.indexOf('AdvancedMobileAccess') == 0 && vcapServices[prop].length > 0) {
 				imfService = vcapServices[prop][0];
 			}
 		}
@@ -102,4 +107,4 @@ function getImfService() {
 	return imfService;
 }
 
-exports = module.exports=FilterUtil
+exports = module.exports = FilterUtil;

--- a/lib/util/filter-util.js
+++ b/lib/util/filter-util.js
@@ -61,10 +61,9 @@ FilterUtil.getAppIdFromUrl = function(url) {
 
 FilterUtil.getApplicationIdFromVcap = function() {
 	if (! applicationId) {
-		var vcapApplication = FilterUtil.getJson(process.env['VCAP_APPLICATION']);
-		applicationId = vcapApplication && vcapApplication['application_id'];
+		var imfService = getImfService();
+		applicationId = imfService && imfService['credentials'] && imfService['credentials']['tenantId'];
 	}
-	
 	return applicationId;
 }
 


### PR DESCRIPTION
Since that the appGuid and the tenantId are different when we will start to support service keys,
we needed to change the backend-strategy  to read the appId from the mca-service tenantId rather then the appEnv (like how its done for the serverUrl using the getImfService func).

*This change wont affect old users since old user have appGuid==tenantId.
So it ok to publish this now.
Can you merge to mater and publish it, I'm not sure how to do that and probably don't have permissions. 
