### PR TITLE
added getClientIdFromVcap,getSecretFromVcap to filter utils

### DIFF
--- a/lib/imf-backend-strategy.js
+++ b/lib/imf-backend-strategy.js
@@ -41,7 +41,12 @@ function Strategy(options) {
 	},{
 		AZFilterAppId: this.appId,
 		AZServerUrl: this.serverUrl,
-		AZTokenProvider: userTokenSDK.getAuthorizationHeader
+		AZTokenProvider: userTokenSDK.getAuthorizationHeader({
+			appId: this.appId ,
+			clientId: FilterUtil.getClientIdFromVcap(),
+			secret: FilterUtil.getSecretFromVcap(),
+			serverUrl: this.serverUrl
+		})
 	});
 	imfStrategy.Strategy.call(this, options);
 	this.name = 'mca-backend-strategy';

--- a/lib/util/filter-util.js
+++ b/lib/util/filter-util.js
@@ -74,6 +74,21 @@ FilterUtil.getServerUrlFromVcap = function() {
 	return serverUrl;
 }
 
+FilterUtil.getClientIdFromVcap = function() {
+	var imfService = getImfService();
+	var clientId = imfService && imfService['credentials'] && imfService['credentials']['clientId'];
+	
+	return clientId;
+}
+
+FilterUtil.getSecretFromVcap = function() {
+	var imfService = getImfService();
+	var secret = imfService && imfService['credentials'] && imfService['credentials']['secret'];
+	
+	return secret;
+}
+
+
 FilterUtil.getArrayFromString = function(value,delim) {
 	var array = [];
 	if (value) {


### PR DESCRIPTION
this is needed since the old imf-oauth-user-sdk take the appGuid from
VCAP_APPLICATION , and since we moved to use service keys this need to
be tenantId, so we pass to  ‘getAuthorizationHeader’ the proper options
so that the appId will be the mac tenantId.
